### PR TITLE
Enhance the Document Upload experience

### DIFF
--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -7,10 +7,10 @@ from starlette.requests import cookie_parser
 from typing_extensions import TypeAlias
 
 from chainlit.auth import (
+    get_client_side_session_from_cookies,
     get_current_user,
     get_token_from_cookies,
     require_login,
-    get_client_side_session_from_cookies,
 )
 from chainlit.auth.jwt import decode_client_side_session
 from chainlit.chat_context import chat_context
@@ -203,7 +203,7 @@ async def connection_successful(sid):
                     chat_context.add(Message.from_dict(step))
 
             await context.emitter.resume_thread(thread)
-            return
+            # return # We need the on_chat_start to be called even when resuming a thread so that we can load the previous chat_context in the MessageHandler
         else:
             await context.emitter.send_resume_thread_error("Thread not found.")
 

--- a/frontend/src/components/Elements/File.tsx
+++ b/frontend/src/components/Elements/File.tsx
@@ -10,7 +10,7 @@ const FileElement = ({ element }: { element: IFileElement }) => {
   return (
     <a
       className={`${element.display}-file no-underline`}
-      download={element.name}
+      // download={element.name}
       href={element.url}
       target="_blank"
     >

--- a/frontend/src/components/chat/Messages/Message/UserMessage.tsx
+++ b/frontend/src/components/chat/Messages/Message/UserMessage.tsx
@@ -15,7 +15,7 @@ import { Pencil } from '@/components/icons/Pencil';
 import { Button } from '@/components/ui/button';
 import { Translator } from 'components/i18n';
 
-// import { InlinedElements } from './Content/InlinedElements';
+import { InlinedElements } from './Content/InlinedElements';
 
 interface Props {
   message: IStep;
@@ -58,7 +58,7 @@ export default function UserMessage({
 
   return (
     <div className="flex flex-col w-full gap-1">
-      {/* <InlinedElements elements={inlineElements} className="items-end" /> */}
+      <InlinedElements elements={inlineElements} className="items-end" />
 
       <div className="flex flex-row items-center gap-1 w-full group">
         {!isEditing && editable && (


### PR DESCRIPTION
- Enable inlined elements in the UI.
- Disable the download action on inlined elements.
- Get the on_chat_start hook executed when resuming a chat as well.